### PR TITLE
Display number of likes for each item on the Homepage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import './style.css';
 const listMovies = new ListMovies();
 
 window.addEventListener('load', async () => {
-  await listMovies.getListLikes()
+  await listMovies.getListLikes();
   await listMovies.getListMovies();
   listMovies.display();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,6 @@ import './style.css';
 const listMovies = new ListMovies();
 
 window.addEventListener('load', async () => {
-  await listMovies.getList();
+  await listMovies.getListMovies();
   listMovies.display();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import './style.css';
 const listMovies = new ListMovies();
 
 window.addEventListener('load', async () => {
+  await listMovies.getListLikes()
   await listMovies.getListMovies();
   listMovies.display();
 });

--- a/src/modules/ListMovies.js
+++ b/src/modules/ListMovies.js
@@ -96,14 +96,11 @@ export default class ListMovies {
     });
   }
 
-  /* involvement API: create a new APP */
-  createApp = async () => {
-    const data = await fetch(`${this.urlInvolvementAPI}/apps/`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      });
-    return data;
+  getListLikes = async () => {
+    const data = await fetch(`${this.urlInvolvementAPI}/apps/${this.appID}/likes/`)
+    await data.json().then((listLikedMovies) => {
+      this.listLikedMovies = listLikedMovies
+    })
   }
 
   saveLike = async (id, likes) => {
@@ -114,5 +111,15 @@ export default class ListMovies {
     });
 
     return result.ok;
+  }
+
+  /* involvement API: create a new APP */
+  createApp = async () => {
+    const data = await fetch(`${this.urlInvolvementAPI}/apps/`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    return data;
   }
 }

--- a/src/modules/ListMovies.js
+++ b/src/modules/ListMovies.js
@@ -59,7 +59,7 @@ export default class ListMovies {
         this.listLikedMovies.filter((item, index) => {
           if (item.item_id === id) {
             likes = item.likes;
-            likeIndex = index
+            likeIndex = index;
           }
           return item;
         });
@@ -77,15 +77,15 @@ export default class ListMovies {
         }
         event.currentTarget.nextSibling.textContent = `${likes} like`;
 
-        //save like on the list
-        if (likeIndex === -1){
-          this.listLikedMovies.push({'item_id': id, 'likes': likes})
+        // save like on the list
+        if (likeIndex === -1) {
+          this.listLikedMovies.push({ item_id: id, likes });
         } else {
-          this.listLikedMovies[likeIndex].likes = likes 
+          this.listLikedMovies[likeIndex].likes = likes;
         }
 
-        //save like on the API
-        this.saveLike(id, likes)
+        // save like on the API
+        this.saveLike(id, likes);
       });
 
       // find the corrent number of like
@@ -95,8 +95,6 @@ export default class ListMovies {
         }
         return item;
       });
-
-
     });
   }
 
@@ -110,10 +108,10 @@ export default class ListMovies {
   }
 
   getListLikes = async () => {
-    const data = await fetch(`${this.urlInvolvementAPI}/apps/${this.appID}/likes/`)
+    const data = await fetch(`${this.urlInvolvementAPI}/apps/${this.appID}/likes/`);
     await data.json().then((listLikedMovies) => {
-      this.listLikedMovies = listLikedMovies
-    })
+      this.listLikedMovies = listLikedMovies;
+    });
   }
 
   saveLike = async (id, likes) => {

--- a/src/modules/ListMovies.js
+++ b/src/modules/ListMovies.js
@@ -51,14 +51,15 @@ export default class ListMovies {
       const ulListMovies = document.getElementById('list-movies');
       ulListMovies.append(liMovies);
 
-      iconLike.addEventListener('click', async (event) => {
+      iconLike.addEventListener('click', (event) => {
         const { id } = liMovies;
         let likes = 0;
-
+        let likeIndex = -1;
         // find the corrent number of like
-        this.listLikedMovies.filter((item) => {
+        this.listLikedMovies.filter((item, index) => {
           if (item.item_id === id) {
             likes = item.likes;
+            likeIndex = index
           }
           return item;
         });
@@ -75,6 +76,16 @@ export default class ListMovies {
           event.currentTarget.classList.add('fa-regular', 'fa-heart');
         }
         event.currentTarget.nextSibling.textContent = `${likes} like`;
+
+        //save like on the list
+        if (likeIndex === -1){
+          this.listLikedMovies.push({'item_id': id, 'likes': likes})
+        } else {
+          this.listLikedMovies[likeIndex].likes = likes 
+        }
+
+        //save like on the API
+        this.saveLike(id, likes)
       });
 
       // find the corrent number of like
@@ -84,6 +95,8 @@ export default class ListMovies {
         }
         return item;
       });
+
+
     });
   }
 

--- a/src/modules/ListMovies.js
+++ b/src/modules/ListMovies.js
@@ -88,7 +88,7 @@ export default class ListMovies {
   }
 
   /* Get list of movies with a GET request to the API:  */
-  getList = async () => {
+  getListMovies = async () => {
     // API Request
     const data = await fetch(`${this.urlApi}?page=${this.currentPage}`);
     await data.json().then((data) => {


### PR DESCRIPTION
In this pull request, I have been able to solve the [issue 12](https://github.com/Trast00/Capston-javascript/issues/12#issue-1516503276): 
- Rename `getList` to `getListMovies` (to avoid confusion with `getListLike`)
- Add in ListMovies.js, the `getListLikes` method to `GET` the list of likes from the [Involvement API](https://www.notion.so/Involvement-API-869e60b5ad104603aa6db59e08150270)